### PR TITLE
Package x86 and x64 together, and fix .NET signing callbacks for x86

### DIFF
--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -60,7 +60,7 @@
     <MakeDir Directories="$(SolutionDir)/packages" />
   </Target>
 
-  <Target Name="BuildNativeLibrary" Condition="$(BuildNativeLibrary) == 'true'" BeforeTargets="EmbedNativeLibraries">
+  <Target Name="BuildNativeX64Library" Condition="$(BuildNativeLibrary) == 'true' AND ($(PlatformTarget) == 'AnyCPU' OR $(PlatformTarget) == 'x64')" BeforeTargets="BuildNativeX86Library">
     <Message Text="Configuring x64 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x64" />
     <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
@@ -70,7 +70,9 @@
     <Exec Command="cmake --build . --config $(CMakeConfig)" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
+  </Target>
 
+  <Target Name="BuildNativeX86Library" Condition="$(BuildNativeLibrary) == 'true' AND ($(PlatformTarget) == 'AnyCPU' OR $(PlatformTarget) == 'x86')" BeforeTargets="EmbedNativeLibraries">
     <Message Text="Configuring x86 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x86" />
     <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch86) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
@@ -82,7 +84,7 @@
     </Exec>
   </Target>
 
-  <Target Name="EmbedNativeLibraries" BeforeTargets="PrepareForBuild" AfterTargets="BuildNativeLibrary">
+  <Target Name="EmbedNativeLibraries" BeforeTargets="PrepareForBuild" AfterTargets="BuildNativeX86Library">
     <ItemGroup>
       <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
     </ItemGroup>

--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net35;net45</TargetFrameworks>
-    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
-    <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
+    <PlatformTarget Condition="$(PlatformTarget) == ''">AnyCPU</PlatformTarget>
     <DefineConstants Condition="$(TargetFramework) == 'netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants Condition="$(TargetFramework) == 'net35'">$(DefineConstants);BCL;BCL35</DefineConstants>
     <DefineConstants Condition="$(TargetFramework) == 'net45'">$(DefineConstants);BCL;BCL45</DefineConstants>
@@ -32,13 +31,16 @@
     <Copyright>Amazon Web Services</Copyright>
     <Description>AWS Common Runtime bindings for .NET</Description>
 
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(PlatformTarget) == 'x64' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015 Win64</CMakeGenerator>
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(PlatformTarget) == 'x64' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017 Win64</CMakeGenerator>
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(PlatformTarget) == 'x64' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator>
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(PlatformTarget) == 'x86' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015</CMakeGenerator>
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(PlatformTarget) == 'x86' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017</CMakeGenerator>
-    <CMakeGenerator Condition="$(CMakeGenerator) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator>
-    <CMakeArch Condition="$(CMakeGenerator) == 'Visual Studio 16 2019'">-A x64</CMakeArch>
+    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015 Win64</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017 Win64</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator64>
+
+    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator86>
+
     <CMakeBinaries Condition="$(OS) == 'Windows_NT' AND $(CODEBUILD_SRC_DIR) != ''">c:/build-$(MSBuildProjectName)</CMakeBinaries>
     <CMakeBinaries Condition="$(OS) == 'Windows_NT' AND $(CODEBUILD_SRC_DIR) == ''">$(ProjectDir)../build</CMakeBinaries>
     <CMakeBinaries Condition="$(OS) != 'Windows_NT'">$(ProjectDir)../build</CMakeBinaries>
@@ -56,28 +58,32 @@
     <MakeDir Directories="$(SolutionDir)/packages" />
   </Target>
 
-  <Target Name="BuildNativeLibrary"
-    Condition="$(BuildNativeLibrary) == 'true'"
-    BeforeTargets="PrepareForBuild">
-    <MakeDir Directories="$(CMakeBinaries)" />
-    <Message Text="Configuring CMake project" Importance="high"/>
-    <Exec Command="cmake -G&quot;$(CMakeGenerator)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch) $(CMakeLibCrypto) $(ProjectDir)../native"
-      WorkingDirectory="$(CMakeBinaries)"
-      ConsoleToMSBuild="true">
+  <Target Name="BuildNativeLibrary" Condition="$(BuildNativeLibrary) == 'true'" BeforeTargets="EmbedNativeLibraries">
+    <Message Text="Configuring x64 CMake project" Importance="high" />
+    <MakeDir Directories="$(CMakeBinaries)/x64" />
+    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -A x64 $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <Message Text="Building native library" Importance="high"/>
-    <Exec Command="cmake --build . --config $(CMakeConfig)" WorkingDirectory="$(CMakeBinaries)" ConsoleToMSBuild="true">
+    <Message Text="Building x64 native library" Importance="high" />
+    <Exec Command="cmake --build . --config $(CMakeConfig)" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Message Text="Configuring x86 CMake project" Importance="high" />
+    <MakeDir Directories="$(CMakeBinaries)/x86" />
+    <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -A Win32 $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+    <Message Text="Building x86 native library" Importance="high" />
+    <Exec Command="cmake --build . --config $(CMakeConfig)" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>
 
-  <Target Name="EmbedNativeLibraries"
-    BeforeTargets="PrepareForBuild"
-    AfterTargets="BuildNativeLibrary">
+  <Target Name="EmbedNativeLibraries" BeforeTargets="PrepareForBuild" AfterTargets="BuildNativeLibrary">
     <ItemGroup>
-      <EmbeddedResource Include="$(CMakeBinaries)/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
+      <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
     </ItemGroup>
-    <Message Text="Embedded library: %(EmbeddedResource.Identity)" Importance="High"/>
+    <Message Text="Embedded library: %(EmbeddedResource.Identity)" Importance="High" />
   </Target>
 </Project>

--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -31,15 +31,17 @@
     <Copyright>Amazon Web Services</Copyright>
     <Description>AWS Common Runtime bindings for .NET</Description>
 
-    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015 Win64</CMakeGenerator64>
-    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017 Win64</CMakeGenerator64>
-    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator64>
-    <CMakeGenerator64 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator64) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015 Win64</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator64) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017 Win64</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator64) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator64>
+    <CMakeGenerator64 Condition="$(CMakeGenerator64) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator64>
+    <CMakeArch64 Condition="$(CMakeGenerator64) == 'Visual Studio 16 2019'">-A x64</CMakeArch64>
 
-    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015</CMakeGenerator86>
-    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017</CMakeGenerator86>
-    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator86>
-    <CMakeGenerator86 Condition="$(CMakeGenerator) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator86) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '14.0'">Visual Studio 14 2015</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator86) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '15.0'">Visual Studio 15 2017</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator86) == '' AND $(OS) == 'Windows_NT' AND $(VisualStudioVersion) == '16.0'">Visual Studio 16 2019</CMakeGenerator86>
+    <CMakeGenerator86 Condition="$(CMakeGenerator86) == '' AND $(OS) == 'Unix'">Unix Makefiles</CMakeGenerator86>
+    <CMakeArch86 Condition="$(CMakeGenerator86) == 'Visual Studio 16 2019'">-A Win32</CMakeArch86>
 
     <CMakeBinaries Condition="$(OS) == 'Windows_NT' AND $(CODEBUILD_SRC_DIR) != ''">c:/build-$(MSBuildProjectName)</CMakeBinaries>
     <CMakeBinaries Condition="$(OS) == 'Windows_NT' AND $(CODEBUILD_SRC_DIR) == ''">$(ProjectDir)../build</CMakeBinaries>
@@ -61,7 +63,7 @@
   <Target Name="BuildNativeLibrary" Condition="$(BuildNativeLibrary) == 'true'" BeforeTargets="EmbedNativeLibraries">
     <Message Text="Configuring x64 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x64" />
-    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -A x64 $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
+    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Text="Building x64 native library" Importance="high" />
@@ -71,7 +73,7 @@
 
     <Message Text="Configuring x86 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x86" />
-    <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -A Win32 $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
+    <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch86) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Text="Building x86 native library" Importance="high" />

--- a/native/src/signing.c
+++ b/native/src/signing.c
@@ -50,14 +50,14 @@ struct aws_signing_config_native {
     uint64_t expiration_in_seconds;
 };
 
-typedef void(aws_dotnet_auth_on_http_request_signing_complete_fn)(
+typedef void(DOTNET_CALL aws_dotnet_auth_on_http_request_signing_complete_fn)(
     uint64_t callback_id,
     int32_t error_code,
     const char *uri,
     struct aws_dotnet_http_header headers[],
     uint32_t header_count);
 
-typedef void(aws_dotnet_auth_on_canonical_request_signing_complete_fn)(
+typedef void(DOTNET_CALL aws_dotnet_auth_on_canonical_request_signing_complete_fn)(
     uint64_t callback_id,
     int32_t error_code,
     const char *authorization_value);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Builds both x64 and x86 versions of the native code when working on Windows and a `PlatformTarget` isn't specified, and packages both as an AnyCPU project
* Tweak two native function definitions to avoid runtime exceptions from a 32-bit process

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
