### PR TITLE
Fix stream callback typedefs

### DIFF
--- a/native/src/stream.c
+++ b/native/src/stream.c
@@ -20,7 +20,7 @@ static int s_aws_input_stream_dotnet_seek(
     enum aws_stream_seek_basis basis) {
 
     struct aws_input_stream_dotnet_impl *impl = stream->impl;
-    bool success = success = impl->delegates.seek((int64_t)offset, (int32_t)basis);
+    bool success = impl->delegates.seek((int64_t)offset, (int32_t)basis);
 
     return success ? AWS_OP_SUCCESS : AWS_OP_ERR;
 }

--- a/native/src/stream.h
+++ b/native/src/stream.h
@@ -8,6 +8,8 @@
 
 #include <aws/common/common.h>
 
+#include "crt.h"
+
 struct aws_input_stream;
 
 enum aws_stream_state {
@@ -15,8 +17,8 @@ enum aws_stream_state {
     STREAM_STATE_DONE,
 };
 
-typedef int(aws_dotnet_stream_read_fn)(uint8_t *buffer, uint64_t buffer_size, uint64_t *bytes_written);
-typedef bool(aws_dotnet_stream_seek_fn)(int64_t offset, int32_t basis);
+typedef int(DOTNET_CALL aws_dotnet_stream_read_fn)(uint8_t *buffer, uint64_t buffer_size, uint64_t *bytes_written);
+typedef bool(DOTNET_CALL aws_dotnet_stream_seek_fn)(int64_t offset, int32_t basis);
 
 struct aws_dotnet_stream_function_table {
     aws_dotnet_stream_read_fn *read;


### PR DESCRIPTION
* Fixes a stack corruption issue due to missing call convention tag on callback typedefs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
