### PR TITLE
Ecs madness

### DIFF
--- a/codebuild/cd/promote-release-build.bat
+++ b/codebuild/cd/promote-release-build.bat
@@ -7,7 +7,7 @@ echo %PKG_VERSION%
 
 call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Tools/VsDevCmd.bat"
 
-bash .\codebuild\cd\pull-signing-secrets.sh
+bash .\codebuild\cd\pull-signing-secrets.sh || goto :error
 
 dotnet build --configuration Release -p:Version=%PKG_VERSION% -p:PackageVersion=%PKG_VERSION% -p:BuildNativeLibrary=false -p:AWSKeyFile=%TEMP%\snk || goto :error
 

--- a/codebuild/cd/pull-signing-secrets.sh
+++ b/codebuild/cd/pull-signing-secrets.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-echo "ECS Uri environment:"
-echo $AWS_CONTAINER_CREDENTIALS_FULL_URI
-echo $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
-
 MSYS_NO_PATHCONV=1 aws --region us-west-2 sts assume-role --role-arn arn:aws:iam::582595803497:role/aws-common-runtime-secrets-role --role-session-name DotnetCrtCD --query Credentials > $TEMP/creds.txt
 
 # these will unset when the script ends

--- a/codebuild/cd/pull-signing-secrets.sh
+++ b/codebuild/cd/pull-signing-secrets.sh
@@ -6,7 +6,7 @@ echo "ECS Uri environment:"
 echo $AWS_CONTAINER_CREDENTIALS_FULL_URI
 echo $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
 
-aws --region us-west-2 sts assume-role --role-arn arn:aws:iam::582595803497:role/aws-common-runtime-secrets-role --role-session-name DotnetCrtCD --query Credentials > $TEMP/creds.txt
+MSYS_NO_PATHCONV=1 aws --region us-west-2 sts assume-role --role-arn arn:aws:iam::582595803497:role/aws-common-runtime-secrets-role --role-session-name DotnetCrtCD --query Credentials > $TEMP/creds.txt
 
 # these will unset when the script ends
 export AWS_ACCESS_KEY_ID=$(cat ${TEMP}/creds.txt | sed -n 's/.*"AccessKeyId": "\(.*\)".*/\1/p')

--- a/codebuild/cd/pull-signing-secrets.sh
+++ b/codebuild/cd/pull-signing-secrets.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+echo "ECS Uri environment:"
+echo $AWS_CONTAINER_CREDENTIALS_FULL_URI
+echo $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+
 aws --region us-west-2 sts assume-role --role-arn arn:aws:iam::582595803497:role/aws-common-runtime-secrets-role --role-session-name DotnetCrtCD --query Credentials > $TEMP/creds.txt
 
 # these will unset when the script ends

--- a/codebuild/win-build-x64-cd.bat
+++ b/codebuild/win-build-x64-cd.bat
@@ -2,6 +2,11 @@
 @setlocal enableextensions enabledelayedexpansion
 
 call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Tools/VsDevCmd.bat"
+
+set PATH=%PATH%;"C:/Program Files/Git/usr/bin"
+
+bash .\codebuild\cd\pull-signing-secrets.sh
+
 dotnet build -f netstandard2.0 --configuration Release -p:PlatformTarget=x64 || goto error
 
 md ..\dist\x64


### PR DESCRIPTION
* Weird path rewriting in git's windows bash implementation was leading to cli ecs credentials sourcing failures

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
