### PR TITLE
Move to Ubuntu18 since Ubuntu 16 packages are MIA

### DIFF
--- a/codebuild/cd/linux-x64-build.yml
+++ b/codebuild/cd/linux-x64-build.yml
@@ -8,7 +8,7 @@ phases:
       - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main"
       - sudo apt-get update -y
       - sudo apt-get install clang-11 cmake -y -f
-      # .NET Core install instructions taken from: https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
+      # .NET Core install instructions taken from: https://dotnet.microsoft.com/download/linux-package-manager/ubuntu18-04/sdk-current
       - curl -L https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb --output /tmp/packages-microsoft-prod.deb
       - sudo dpkg -i /tmp/packages-microsoft-prod.deb
       - sudo apt-get install apt-transport-https


### PR DESCRIPTION
While possibly a mistake on Microsoft's part, the ubuntu 16 dotnet core packages have gone MIA and it might be a good idea to move to 18 even if they come back due to support issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
