### PR TITLE
Shrink Release binary size

### DIFF
--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -52,8 +52,7 @@
 
     <CMakeBinaries>$(ProjectDir)../build</CMakeBinaries>
     <CMakeConfig Condition="$(Configuration) == 'Debug'">Debug</CMakeConfig>
-    <CMakeConfig Condition="$(CMakeConfig) == ''">RelWithDebInfo</CMakeConfig>
-    <CMakeLibCrypto Condition="$(LibCryptoPath) != ''">-DLibCrypto_INCLUDE_DIR=$(LibCryptoPath)/include -DLibCrypto_STATIC_LIBRARY=$(LibCryptoPath)/lib/libcrypto.a</CMakeLibCrypto>
+    <CMakeConfig Condition="$(CMakeConfig) == ''">Release</CMakeConfig>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CMake" Version="3.5.2" />
@@ -68,7 +67,7 @@
   <Target Name="BuildNativeX64Library" Condition="$(BuildNativeLibrary) == 'true' AND ($(PlatformTarget) == 'AnyCPU' OR $(PlatformTarget) == 'x64')" BeforeTargets="BuildNativeX86Library">
     <Message Text="Configuring x64 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x64" />
-    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
+    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) -DCMAKE_VERBOSE_MAKEFILE=ON $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Text="Building x64 native library" Importance="high" />
@@ -80,7 +79,7 @@
   <Target Name="BuildNativeX86Library" Condition="$(BuildNativeLibrary) == 'true' AND ($(PlatformTarget) == 'AnyCPU' OR $(PlatformTarget) == 'x86') AND $(OS) == 'Windows_NT'" BeforeTargets="EmbedNativeLibraries">
     <Message Text="Configuring x86 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x86" />
-    <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch86) $(CMakeLibCrypto) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
+    <Exec Command="cmake -G&quot;$(CMakeGenerator86)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch86) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x86" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Text="Building x86 native library" Importance="high" />
@@ -91,7 +90,7 @@
 
   <Target Name="EmbedNativeLibraries" BeforeTargets="PrepareForBuild" AfterTargets="BuildNativeX86Library">
     <ItemGroup>
-      <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
+        <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
     </ItemGroup>
     <Message Text="Embedded library: %(EmbeddedResource.Identity)" Importance="High" />
   </Target>

--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -67,7 +67,7 @@
   <Target Name="BuildNativeX64Library" Condition="$(BuildNativeLibrary) == 'true' AND ($(PlatformTarget) == 'AnyCPU' OR $(PlatformTarget) == 'x64')" BeforeTargets="BuildNativeX86Library">
     <Message Text="Configuring x64 CMake project" Importance="high" />
     <MakeDir Directories="$(CMakeBinaries)/x64" />
-    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) -DCMAKE_VERBOSE_MAKEFILE=ON $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
+    <Exec Command="cmake -G&quot;$(CMakeGenerator64)&quot; -DCMAKE_BUILD_TYPE=$(CMakeConfig) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $(CMakeArch64) $(ProjectDir)../native" WorkingDirectory="$(CMakeBinaries)/x64" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Text="Building x64 native library" Importance="high" />
@@ -90,7 +90,7 @@
 
   <Target Name="EmbedNativeLibraries" BeforeTargets="PrepareForBuild" AfterTargets="BuildNativeX86Library">
     <ItemGroup>
-        <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
+      <EmbeddedResource Include="$(CMakeBinaries)/*/lib/*aws-crt-dotnet*" Exclude="**/*.ilk" />
     </ItemGroup>
     <Message Text="Embedded library: %(EmbeddedResource.Identity)" Importance="High" />
   </Target>

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -118,6 +118,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (CMAKE_BUILD_TYPE STREQUAL Release)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${PROJECT_NAME}>)
+# Strip debug symbols from s2n and libcrypto to keep the .so size down
+if (UNIX AND NOT APPLE AND CMAKE_BUILD_TYPE STREQUAL Release AND CMAKE_STRIP)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_LINK COMMAND ${CMAKE_STRIP} --strip-debug $<TARGET_FILE:s2n>)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_LINK COMMAND ${CMAKE_STRIP} --strip-debug $<TARGET_FILE:crypto>)
 endif()

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -117,3 +117,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "-DAWS_DOTNET_EXPORTS")
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
+
+if (CMAKE_BUILD_TYPE STREQUAL Release)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${PROJECT_NAME}>)
+endif()


### PR DESCRIPTION
* Shrinks aws-crt.dll from 7.4 MB to 3.3 MB
* Also removes libcrypto cruft from csproj


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
