### PR TITLE
Add 5.0 support to CI tests

### DIFF
--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -8,6 +8,7 @@ import Builder
 from pathlib import Path
 import os
 import urllib.parse
+import pdb
 
 URLs = {
     'linux': 'https://dot.net/v1/dotnet-install.sh',
@@ -21,12 +22,14 @@ class DotNet(Builder.Import):
         super().__init__(config={}, **kwargs)
         self.path = None
         self.installed = False
-        self.channel = 'LTS'
+        self.channels = ['LTS']
 
     def resolved(self):
         return True
 
     def install(self, env):
+        pdb.set_trace()
+
         if self.installed:
             return
 
@@ -55,16 +58,18 @@ class DotNet(Builder.Import):
 
         fetch_script(script_url, script)
 
-        arch = env.spec.arch
-        if env.spec.target == 'windows':
-            command = '{} -Channel {} -Architecture {} -InstallDir {}'.format(
-                script, self.channel, arch, install_dir).split(' ')
-        else:
-            command = '{} --channel {} --architecture {} --install-dir {}'.format(
-                script, self.channel, arch, install_dir).split(' ')
+        for version in self.channels:
+            arch = env.spec.arch
+            if env.spec.target == 'windows':
+                command = '{} -Channel {} -Architecture {} -InstallDir {}'.format(
+                    script, version, arch, install_dir).split(' ')
+            else:
+                command = '{} --channel {} --architecture {} --install-dir {}'.format(
+                    script, version, arch, install_dir).split(' ')
 
-        # Run installer
-        sh.exec(command, check=True)
+            # Run installer
+            sh.exec(command, check=True)
+
         # Add to PATH
         sh.setenv('PATH', '{}:{}'.format(sh.getenv('PATH'), install_dir))
         self.installed = True
@@ -73,26 +78,26 @@ class DotNet(Builder.Import):
 class DotNetCore(DotNet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.channel = 'LTS'
+        self.channels = ['2.1', '3.1', '5.0']
 
 
 class DotNetCore21(DotNetCore):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.channel = '2.1'
+        self.channels = ['2.1']
 
 
 class DotNetCore31(DotNetCore):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.channel = '3.1'
+        self.channels = ['3.1']
 
 class DotNetCore50(DotNetCore):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.channel = '5.0'
+        self.channels = ['5.0']
 
 class DotNetCore60(DotNetCore):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.channel = '6.0'
+        self.channels = ['6.0']

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -8,7 +8,6 @@ import Builder
 from pathlib import Path
 import os
 import urllib.parse
-import pdb
 
 URLs = {
     'linux': 'https://dot.net/v1/dotnet-install.sh',
@@ -28,7 +27,6 @@ class DotNet(Builder.Import):
         return True
 
     def install(self, env):
-        pdb.set_trace()
 
         if self.installed:
             return

--- a/builder.json
+++ b/builder.json
@@ -5,7 +5,7 @@
         "dotnet pack -p:TargetFrameworks=netstandard2.0 -p:PlatformTarget={platform_target} ."
     ],
     "test_steps": [
-        "dotnet test tests/tests.csproj -v normal -p:PlatformTarget={platform_target} -f netcoreapp3.1"
+        "dotnet test tests/tests.csproj -v normal -p:PlatformTarget={platform_target}"
     ],
     "imports": [
         "dotnetcore"

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Adds 5.0 target to tests.  Update builder's dotnet install to install multiple frameworks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
