### PR TITLE
CMake as build-only dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   linux-compat:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         image:
@@ -31,7 +31,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   linux-arm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         arch: [arm64]
@@ -68,7 +68,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --spec downstream
 
   clang-sanitizers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         sanitizers: [",thread", ",address,undefined"]
@@ -80,7 +80,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-11 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
 
   windows-vc16:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         arch: [x64]
@@ -96,7 +96,7 @@ jobs:
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   windows-vc14:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         arch: [x86, x64]
@@ -113,7 +113,7 @@ jobs:
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} downstream
 
   osx:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
@@ -122,7 +122,7 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   check-submodules:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout Source
       uses: actions/checkout@v2

--- a/aws-crt/aws-crt.csproj
+++ b/aws-crt/aws-crt.csproj
@@ -54,7 +54,9 @@
     <CMakeConfig Condition="$(CMakeConfig) == ''">Release</CMakeConfig>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CMake" Version="3.5.2" />
+    <PackageReference Include="CMake" Version="3.5.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' != 'net35'" Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Experimental change to try and make CMake a build-only dependency so that nuget consumption does not require it.  Will require a successful release and external consumption from nuget package to verify validity.

Also updates CI (which was about 4 months stale) to pinned Windows/Mac images and removes netcoreapp2.1 as a test run target.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
