### PR TITLE
print dotnet version to codebuild logs

### DIFF
--- a/codebuild/cd/promote-release-build.bat
+++ b/codebuild/cd/promote-release-build.bat
@@ -9,6 +9,7 @@ call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Too
 
 bash .\codebuild\cd\pull-signing-secrets.sh || goto :error
 
+dotnet --info
 dotnet build --configuration Release -p:Version=%PKG_VERSION% -p:PackageVersion=%PKG_VERSION% -p:BuildNativeLibrary=false -p:AWSKeyFile=%TEMP%\snk || goto :error
 
 aws secretsmanager get-secret-value --secret-id "NuGet/push" --query SecretString | cut -f2 -d\ > nuget_key.txt || goto :error

--- a/codebuild/cd/publish-rc-build.bat
+++ b/codebuild/cd/publish-rc-build.bat
@@ -9,6 +9,7 @@ call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Too
 
 bash .\codebuild\cd\pull-signing-secrets.sh
 
+dotnet --info
 dotnet build --configuration Release -p:Version=%PKG_VERSION% -p:PackageVersion=%PKG_VERSION%-rc -p:BuildNativeLibrary=false -p:AWSKeyFile=%TEMP%\snk || goto :error
 
 aws secretsmanager get-secret-value --secret-id "NuGet/push" --query SecretString | cut -f2 -d\ > nuget_key.txt || goto :error

--- a/codebuild/cd/win-build.bat
+++ b/codebuild/cd/win-build.bat
@@ -3,6 +3,7 @@
 
 call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/Common7/Tools/VsDevCmd.bat"
 
+dotnet --info
 dotnet build -f netstandard2.0 --configuration Release -p:AwsCrtPlatformTarget=%1 || goto error
 
 md ..\dist\%1\lib


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Print dotnet version during builds


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
