### PR TITLE
Mono Sigv4a fix

### DIFF
--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -38,7 +38,8 @@ class DotNet(Builder.Import):
         if dotnet_path:
             self.path = dotnet_path
             self.installed = True
-            print('already_installed={}'.format(dotnet_path))
+            print
+            print('already_installed path={} sdks={}'.format(dotnet_path, sh.exec('dotnet --list-sdks')))
             return
 
         script_url = URLs.get(env.spec.target, None)

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -28,6 +28,7 @@ class DotNet(Builder.Import):
 
     def install(self, env):
 
+        print('running install')
         if self.installed:
             return
 
@@ -37,6 +38,7 @@ class DotNet(Builder.Import):
         if dotnet_path:
             self.path = dotnet_path
             self.installed = True
+            print('already_installed={}'.format(dotnet_path))
             return
 
         script_url = URLs.get(env.spec.target, None)
@@ -69,7 +71,7 @@ class DotNet(Builder.Import):
                     script, version, arch, install_dir).split(' ')
 
             print('running={}'.format(command))
-            
+
             # Run installer
             sh.exec(command, check=True)
 

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -68,6 +68,8 @@ class DotNet(Builder.Import):
                 command = '{} --channel {} --architecture {} --install-dir {}'.format(
                     script, version, arch, install_dir).split(' ')
 
+            print('running={}'.format(command))
+            
             # Run installer
             sh.exec(command, check=True)
 

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -35,12 +35,11 @@ class DotNet(Builder.Import):
         sh = env.shell
 
         dotnet_path = sh.where('dotnet')
-        if dotnet_path:
-            self.path = dotnet_path
-            self.installed = True
-            print
-            print('already_installed path={} sdks={}'.format(dotnet_path, sh.exec('dotnet --list-sdks')))
-            return
+        #if dotnet_path:
+        #    self.path = dotnet_path
+        #    self.installed = True
+        #    print('already_installed path={} sdks={}'.format(dotnet_path, sh.exec('dotnet --list-sdks')))
+        #    return
 
         script_url = URLs.get(env.spec.target, None)
         if not script_url:

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -28,7 +28,7 @@ class DotNet(Builder.Import):
 
     def install(self, env):
 
-        print('running install')
+        print('running install {}'.format(self.channels))
         if self.installed:
             return
 

--- a/.builder/dotnet.py
+++ b/.builder/dotnet.py
@@ -28,18 +28,16 @@ class DotNet(Builder.Import):
 
     def install(self, env):
 
-        print('running install {}'.format(self.channels))
         if self.installed:
             return
 
         sh = env.shell
 
         dotnet_path = sh.where('dotnet')
-        #if dotnet_path:
-        #    self.path = dotnet_path
-        #    self.installed = True
-        #    print('already_installed path={} sdks={}'.format(dotnet_path, sh.exec('dotnet --list-sdks')))
-        #    return
+        if dotnet_path:
+            self.path = dotnet_path
+            self.installed = True
+            return
 
         script_url = URLs.get(env.spec.target, None)
         if not script_url:
@@ -69,8 +67,6 @@ class DotNet(Builder.Import):
             else:
                 command = '{} --channel {} --architecture {} --install-dir {}'.format(
                     script, version, arch, install_dir).split(' ')
-
-            print('running={}'.format(command))
 
             # Run installer
             sh.exec(command, check=True)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} downstream
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --compiler msvc-14 downstream
 
   osx:
     runs-on: macos-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --spec downstream
 
   linux_mono:
-    name: Linux mono test
     runs-on: ubuntu-20.04 
     steps:
       - name: Build ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,16 @@ jobs:
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --spec downstream
 
+  linux_mono:
+    name: Linux mono test
+    runs-on: ubuntu-20.04 
+    steps:
+      - name: Build ${{ env.PACKAGE_NAME }}
+        run: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }} --variant=mono_test
+
   clang-sanitizers:
     runs-on: ubuntu-20.04
     strategy:

--- a/aws-crt-auth/Signing.cs
+++ b/aws-crt-auth/Signing.cs
@@ -165,7 +165,7 @@ namespace Aws.Crt.Auth
                 [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=3)] byte[] signatureBuffer,
                 UInt64 signatureBufferSize,
                 [MarshalAs(UnmanagedType.LPStr)] string signedUri, 
-                [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=6)] HttpHeader[] signedHeaders, 
+                [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex=6)] HttpHeaderNative[] signedHeaders, 
                 UInt32 signedHeaderCount);
 
             [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
@@ -281,7 +281,7 @@ namespace Aws.Crt.Auth
         private static StrongReferenceVendor<ChunkSigningCallbackData> PendingChunkSignings = new StrongReferenceVendor<ChunkSigningCallbackData>();
         private static StrongReferenceVendor<TrailingHeadersSigningCallbackData> PendingTrailingHeadersSignings = new StrongReferenceVendor<TrailingHeadersSigningCallbackData>();
 
-        private static void OnHttpRequestSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeader[] headers, uint headerCount)
+        private static void OnHttpRequestSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeaderNative[] headers, uint headerCount)
         {
             HttpRequestSigningCallbackData callback = PendingHttpRequestSignings.ReleaseStrongReference(id);
             if (callback == null) {
@@ -298,7 +298,7 @@ namespace Aws.Crt.Auth
                 HttpRequest signedRequest = new HttpRequest();
                 signedRequest.Method = sourceRequest.Method;
                 signedRequest.Uri = uri;
-                signedRequest.Headers = headers;
+                signedRequest.Headers = Array.ConvertAll(headers, header => new HttpHeader(header.Name, header.Value));
                 signedRequest.BodyStream = sourceRequest.BodyStream;
 
                 CrtSigningResult result = new CrtSigningResult();
@@ -340,7 +340,7 @@ namespace Aws.Crt.Auth
             return callback.Result;
         }
 
-        private static void OnCanonicalRequestSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeader[] headers, uint headerCount)
+        private static void OnCanonicalRequestSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeaderNative[] headers, uint headerCount)
         {
             CanonicalRequestSigningCallbackData callback = PendingCanonicalRequestSignings.ReleaseStrongReference(id);
             if (callback == null) {
@@ -392,7 +392,7 @@ namespace Aws.Crt.Auth
             return callback.Result;
         }     
 
-        private static void OnChunkSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeader[] headers, uint headerCount)
+        private static void OnChunkSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeaderNative[] headers, uint headerCount)
         {
             ChunkSigningCallbackData callback = PendingChunkSignings.ReleaseStrongReference(id);
             if (callback == null) {
@@ -435,7 +435,7 @@ namespace Aws.Crt.Auth
             return callback.Result;
         }
 
-        private static void OnTrailingHeadersSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeader[] headers, uint headerCount)
+        private static void OnTrailingHeadersSigningComplete(ulong id, int errorCode, byte[] signatureBuffer, ulong signatureBufferSize, string uri, HttpHeaderNative[] headers, uint headerCount)
         {
             TrailingHeadersSigningCallbackData callback = PendingTrailingHeadersSignings.ReleaseStrongReference(id);
             if (callback == null) {

--- a/aws-crt-http/HttpConnection.cs
+++ b/aws-crt-http/HttpConnection.cs
@@ -153,6 +153,17 @@ namespace Aws.Crt.Http
         }
     }
 
+    /*
+    * Note: Mono does not support marshalling of arrays with non-blittable
+    * members from native (but it can marshall them to native). 
+    * HttpHeaderNative is a blittable version of HttpHeader
+    * (both can marshall aws_dotnet_http_header from native).
+    * Use HttpHeaderNative in callbacks from native that need to pass array of
+    * headers. And HttpHeader otherwise.
+    * Note: HttpHeaderNative holds on to native string pointer, so its only valid
+    * while native pointer is valid, i.e. within the callback, and needs to be
+    * transformed to HttpHeader if data is used outside of callback scope.
+    */
     [StructLayout(LayoutKind.Sequential)]
     public struct HttpHeaderNative
     {

--- a/aws-crt-http/HttpConnection.cs
+++ b/aws-crt-http/HttpConnection.cs
@@ -135,10 +135,10 @@ namespace Aws.Crt.Http
     public struct HttpHeader
     {
         [MarshalAs(UnmanagedType.LPStr)]
-        public string Name;
+        public readonly string Name;
 
         [MarshalAs(UnmanagedType.LPStr)]
-        public string Value;
+        public readonly string Value;
 
         private Int32 nameSize;
 

--- a/aws-crt-http/HttpConnection.cs
+++ b/aws-crt-http/HttpConnection.cs
@@ -135,21 +135,39 @@ namespace Aws.Crt.Http
     public struct HttpHeader
     {
         [MarshalAs(UnmanagedType.LPStr)]
-        public readonly string Name;
+        private string name;
 
         [MarshalAs(UnmanagedType.LPStr)]
-        public readonly string Value;
+        private string value;
 
         private Int32 nameSize;
 
         private Int32 valueSize;
 
+        public String Name
+        {
+            get { return this.name; }
+            set {
+                this.name = value;
+                this.nameSize = this.name.Length;
+            }
+        }
+
+        public String Value
+        {
+            get { return this.value; }
+            set {
+                this.value = value;
+                this.valueSize = this.value.Length;
+            }
+        }
+
         public HttpHeader(string name, string value)
         {
-            Name = name;
-            Value = value;
-            nameSize = name.Length;
-            valueSize = value.Length;
+            this.name = name;
+            this.value = value;
+            this.nameSize = name.Length;
+            this.valueSize = value.Length;
         }
     }
 

--- a/builder.json
+++ b/builder.json
@@ -84,5 +84,13 @@
                 }
             }
         }
+    },
+
+    "variants": {
+        "mono_test" : {
+            "!test_steps": [
+                "dotnet build tests/tests.csproj -t:MonoTest {build_tests_args}"
+            ]
+        }
     }
 }

--- a/native/src/http_client.c
+++ b/native/src/http_client.c
@@ -191,7 +191,6 @@ struct aws_http_message *aws_build_http_request(
         goto on_error;
     }
 
-
     for (size_t i = 0; i < header_count; ++i) {
         struct aws_http_header header;
         AWS_ZERO_STRUCT(header);

--- a/native/src/http_client.c
+++ b/native/src/http_client.c
@@ -125,24 +125,18 @@ static int s_stream_on_incoming_headers(
     (void)s;
 
     struct aws_dotnet_http_stream *stream = user_data;
-    struct aws_allocator *allocator = aws_dotnet_get_allocator();
     AWS_VARIABLE_LENGTH_ARRAY(struct aws_dotnet_http_header, dotnet_headers, header_count);
-    AWS_VARIABLE_LENGTH_ARRAY(struct aws_string *, header_strings, header_count * 2);
+
     for (size_t header_idx = 0; header_idx < header_count; ++header_idx) {
-        header_strings[header_idx] =
-            aws_string_new_from_array(allocator, headers[header_idx].name.ptr, headers[header_idx].name.len);
-        header_strings[header_idx + 1] =
-            aws_string_new_from_array(allocator, headers[header_idx].value.ptr, headers[header_idx].value.len);
-        dotnet_headers[header_idx].name = (const char *)header_strings[header_idx]->bytes;
-        dotnet_headers[header_idx].value = (const char *)header_strings[header_idx + 1]->bytes;
+        dotnet_headers[header_idx].name = (const char *)headers[header_idx].name.ptr;
+        dotnet_headers[header_idx].name_size = headers[header_idx].name.len;
+        dotnet_headers[header_idx].value = (const char *)headers[header_idx].value.ptr;
+        dotnet_headers[header_idx].value_size = headers[header_idx].value.len;
     }
 
     int status = 0;
     aws_http_stream_get_incoming_response_status(stream->stream, &status);
     stream->on_incoming_headers(status, header_block, dotnet_headers, (uint32_t)header_count);
-    for (size_t idx = 0; idx < header_count * 2; ++idx) {
-        aws_string_destroy(header_strings[idx]);
-    }
 
     return AWS_OP_SUCCESS;
 }
@@ -197,12 +191,16 @@ struct aws_http_message *aws_build_http_request(
         goto on_error;
     }
 
+
     for (size_t i = 0; i < header_count; ++i) {
         struct aws_http_header header;
         AWS_ZERO_STRUCT(header);
 
-        header.name = aws_byte_cursor_from_c_str(headers[i].name);
-        header.value = aws_byte_cursor_from_c_str(headers[i].value);
+        struct aws_string *name_string = aws_string_new_from_c_str(allocator, headers[i].name);
+        struct aws_string *value_string = aws_string_new_from_c_str(allocator, headers[i].value);
+
+        header.name = aws_byte_cursor_from_string(name_string);
+        header.value = aws_byte_cursor_from_string(value_string);
         if (aws_http_message_add_header(request, header)) {
             goto on_error;
         }

--- a/native/src/http_client.h
+++ b/native/src/http_client.h
@@ -14,6 +14,8 @@ struct aws_dotnet_stream_function_table;
 struct aws_dotnet_http_header {
     const char *name;
     const char *value;
+    int32_t name_size;
+    int32_t value_size;
 };
 
 struct aws_http_message *aws_build_http_request(

--- a/tests/SigningTest.cs
+++ b/tests/SigningTest.cs
@@ -151,7 +151,7 @@ namespace tests
 
             Assert.Equal("GET", signedRequest.Method);
             Assert.Equal("/?Param-3=Value3&Param=Value2&%E1%88%B4=Value1&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIDEXAMPLE%2F20150830%2Fus-east-1%2Fservice%2Faws4_request&X-Amz-Date=20150830T123600Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=c5f1848ceec943ac2ca68ee720460c23aaae30a2300586597ada94c4a65e4787", signedRequest.Uri);
-            Assert.Equal(1, signedRequest.Headers.Length);
+            Assert.Single(signedRequest.Headers);
             Assert.True(HasHeader(signedRequest, "Host", "example.amazonaws.com"));
 
             byte[] signature = signingResult.Signature;
@@ -267,7 +267,7 @@ namespace tests
 
             /* Verify Skip is not in the signed headers component of the Authorization header */
             String authValue = GetHeaderValue(signedRequest, "Authorization");
-            Assert.Equal(false, authValue.Contains("Skip"));
+            Assert.DoesNotContain(authValue, "Skip");
         }    
 
         [Fact]

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -9,15 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -4,7 +4,7 @@
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>
-    <XunitConsole>mono $(NuGetPackageRoot)xunit.runner.console/2.4.2/tools/net472/xunit.console.exe</XunitConsole>
+    <XunitConsole>$(NuGetPackageRoot)xunit.runner.console/2.4.2/tools/net472/xunit.console.exe</XunitConsole>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(PlatformTarget) == 'x64'">
@@ -36,8 +36,10 @@
     <PackageReference Include="AWSCRT-CHECKSUMS" Version="1.0.0-dev" />
   </ItemGroup>
 
+  <!-- TODO: Tests use System.IO.MemoryStream in several places and mono
+  struggles to find when tests target net5.0. Run tests against netcore only. -->
   <Target Name="MonoTest" DependsOnTargets="Build">
-    <Exec Command="$(XunitConsole) $(MSBuildProjectDirectory)/$(OutputPath)netcoreapp3.1/tests.dll" />
+    <Exec Command="mono $(XunitConsole) $(MSBuildProjectDirectory)/$(OutputPath)netcoreapp3.1/tests.dll" />
   </Target>
 
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,18 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.0' OR $(TargetFramework) == 'netcoreapp3.1'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'net452'">
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -12,14 +12,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.0' OR $(TargetFramework) == 'netcoreapp3.1'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'net452'">
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  
-  <PropertyGroup Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">
-        <TargetFrameworks>>netcoreapp3.1</TargetFrameworks>
-        <PlatformTarget>x86</PlatformTarget>
-        <IsPackable>false</IsPackable>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
+    <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition="$(PlatformTarget) == ''"> 
-      <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-      <PlatformTarget>x64</PlatformTarget>
-      <IsPackable>false</IsPackable>
+
+  <PropertyGroup Condition="$(PlatformTarget) == 'x64'">
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(PlatformTarget) == 'x86'">
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,16 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
+  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.0' OR $(TargetFramework) == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net452'">
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
-    <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <PlatformTarget>x86</PlatformTarget>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(PlatformTarget) == ''"> 
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <PlatformTarget>x64</PlatformTarget>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,16 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>
+    <XunitConsole>mono $(NuGetPackageRoot)xunit.runner.console/2.4.2/tools/net472/xunit.console.exe</XunitConsole>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(PlatformTarget) == 'x64'">
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- TODO: github actions windows-2019 image no longer inlcudes x86 version of
+    net5.0 (only 3.1 and 6.0 are available) and our script for installing deps.
+    is broken on windows.
+    Disable net5.0 for x86 for now and migrate to 6.0 (5.0 is eol)/fix dep
+    script. -->
   <PropertyGroup Condition="$(PlatformTarget) == 'x86'">
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
@@ -18,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -31,5 +35,10 @@
     <PackageReference Include="AWSCRT-CAL" Version="1.0.0-dev" />
     <PackageReference Include="AWSCRT-CHECKSUMS" Version="1.0.0-dev" />
   </ItemGroup>
+
+  <Target Name="MonoTest" DependsOnTargets="Build">
+    <Exec Command="$(XunitConsole) $(MSBuildProjectDirectory)/$(OutputPath)netcoreapp3.1/tests.dll" />
+  </Target>
+
 
 </Project>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
+    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT'
+    AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) ==
+    'Visual Studio 15 2017' OR $(CMakeGenerator) == 'Visual Studio 16 2019')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -2,15 +2,15 @@
 
   
   <PropertyGroup Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>>netcoreapp3.1</TargetFrameworks>
         <PlatformTarget>x86</PlatformTarget>
         <IsPackable>false</IsPackable>
-    </PropertyGroup>
-    <PropertyGroup Condition="$(PlatformTarget) == ''"> 
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-        <PlatformTarget>x64</PlatformTarget>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(PlatformTarget) == ''"> 
+      <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+      <PlatformTarget>x64</PlatformTarget>
+      <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT'
-    AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) ==
-    'Visual Studio 15 2017' OR $(CMakeGenerator) == 'Visual Studio 16 2019')">x86</PlatformTarget>
+    <PlatformTarget Condition="$(PlatformTarget) == '' AND $(OS) == 'Windows_NT' AND ($(CMakeGenerator) == 'Visual Studio 14 2015' OR $(CMakeGenerator) == 'Visual Studio 15 2017')">x86</PlatformTarget>
     <PlatformTarget Condition="$(PlatformTarget) == ''">x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Mono does not support marshaling native arrays of non-blittable types and callbacks that pass back arrays of headers fail (sigv4, etc...). HttpHeader struct is non-blittable since it has 2 string members that are marshaled to c string.
Note: http headers seems to be the only place in the bindings where we marshal arrays of non-blittable types.

This change introduces a new blittable type HttpHeaderNative that callbacks use. We wrap all callbacks on dotnet side and transform HttpHeaderNative to HttpHeader, so external interface will still use HttpHeader.

Why not have one uber type that can handle marshaling from/to native?
Memory management becomes a major pain. Allocation on managed side requires a free on managed side, so native side has to do a copy or call managed free. And allocating on native side requires managed side to take over allocated mem, which is a major pain as well.

Why not have a custom marshaler?
Custom marshalers cannot be used in conjunction with array marshaler, so it would require implementing array marshaling logic as well. Arguably custom marshaler is a cleaner looking solution over pushing some marshaling logic to callback, but the code to support it is really ugly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
