### PR TITLE
fix dotnet arm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   linux-arm:
-    runs-on: ubuntu-22.04 # temporarily downgrade to old ubuntu as 24.04 likes to segfault in the middle of the build for arm build
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         arch: [arm64]
@@ -46,7 +46,7 @@ jobs:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      run: docker run --privileged --rm tonistiigi/binfmt --install aarch64
         # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We rely on qemu to test aarch64 on x86-64 github runners.
Qemu had a bug where they had a bug with incorrectly mapping address space. That mostly worked fine until kernel patch that increased entropy in their address randomization. TLDR; qemu likes to segfault a lot against new kernels on our aarch64 test. Solution is to switch to a different github qemu user static image that forces a latest version of qemu, that has the bug fixed.
if you want to read more - https://github.com/tonistiigi/binfmt/issues/240

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
